### PR TITLE
Update CV with current role at Bose and refined experience

### DIFF
--- a/cv.tex
+++ b/cv.tex
@@ -38,42 +38,39 @@
 
 % Professional summary
 \CVSection{Professional Summary}
-Experienced software engineer with 9+ years building and scaling distributed systems. Specialized in platform engineering and microservices architecture, with hands-on expertise in Java and Go for cloud-native applications. Led critical platform transformations at Carlsberg, enabling product teams to scale across 10 European markets while establishing engineering best practices. Passionate about developer experience, API design, and building resilient systems that balance innovation with operational excellence.
+Software engineer with 9+ years building and scaling distributed systems, now leading two B2B engineering teams at Bose. Specialized in platform engineering and microservices architecture, with hands-on expertise in Java and Go for cloud-native applications. Led critical platform transformations at Carlsberg, enabling product teams to scale across 10 European markets. Strong track record in API design, developer experience, and turning legacy systems into reliable, modern platforms.
 \Sep
 
 % Skills
 \CVSection{Skills}
 \begin{itemize}[leftmargin=*,label={•}]
-    \item \textbf{Platform Engineering:} API design, Developer experience, Inner-source practices
-    \item \textbf{Programming:} Java (expert), Go (serverless/Lambda), Python, TypeScript
-    \item \textbf{Cloud \& DevOps:} AWS (Lambda, ECS/Fargate, EventBridge), Azure, Terraform, GitHub Actions
+    \item \textbf{Platform Engineering:} API design, developer experience, inner-source practices
+    \item \textbf{Programming:} Java (expert), Go, Python, TypeScript
+    \item \textbf{Cloud \& DevOps:} AWS (Lambda, ECS/Fargate, EventBridge), Azure, Docker, Terraform, GitHub Actions, Datadog
+    \item \textbf{Data \& Messaging:} MongoDB, DynamoDB, DocumentDB, OpenSearch, Kafka
     \item \textbf{Languages:} Portuguese (native), Spanish (native), English (C2), French (C1)
 \end{itemize}
 \Sep
 
 % Education
 \CVSection{Education}
-\CVItem{2011--2015, ISCTE–University Institute of Lisbon}{BSc in Software Engineering (completed select MSc coursework)}
+\CVItem{2011--2015, ISCTE–University Institute of Lisbon}{BSc in Software Engineering (with postgraduate coursework in Information Systems \& Computer Engineering)}
 \Sep
 
 % Experience
 \CVSection{Experience}
 % Bose - condensed
 \CVItem{Mar 2025–Present, \textit{Tech Lead}, Bose}{
-Leading two B2B teams: one focused on e-commerce platform (AEM, Hybris, microservices architecture) and another handling enterprise integrations, ERP and CRM systems. Restructuring development practices to improve delivery quality and team efficiency across distributed locations.
+Leading two B2B teams (~5 engineers each): one focused on e-commerce platform (AEM, Hybris, microservices architecture) and another handling enterprise integrations, ERP and CRM systems. Restructuring development practices to improve delivery quality and team efficiency across distributed locations.
 }
 
 \CVItem{Jan 2019–Dec 2024, \textit{Software Engineer $\rightarrow$ Platform Engineer $\rightarrow$ Tech Lead}, Carlsberg Group}{
 \begin{itemize}[leftmargin=*,label={•},itemsep=0.3em]
     \item \textbf{CADI Platform (2019–2021):} Architected greenfield microservices sales platform on AWS Fargate, delivering MVP in 7 months and scaling to 9 European markets within 18 months. Built event-driven backend architecture for real-time data synchronization, while implementing offline-first mobile design ensuring sales teams could operate without constant connectivity. Achieved 99.98\% availability (2 hours total downtime) while continuously adding functionality.
     
-    \item \textbf{Platform Engineering Team (2022–2023):} 
-    Refactored legacy monolithic services into event-driven microservices, improving system reliability and migrated critical event processing workloads to Go-based serverless functions, reducing cold-start latency compared to Java implementations.\\
-    Led initiative to build reusable, API-first platform services adopted by 8 product teams while championing for innersource practices \\
-    Reengineered branch strategy from 2-week release branches to automated trunk-based CI/CD with feature flags, reducing deployment lead time from 14 days to near real-time after commit.\\ Implemented Datadog observability stack on AWS Fargate using sidecar agent containers and Java APM agent integration, enabling full metrics, logs, and trace visibility across services. 
+    \item \textbf{Platform Engineering Team (2022–2023):} Refactored monolithic services into event-driven microservices; introduced Go-based serverless functions for event-processing workloads (fast cold-start, low overhead vs. Java/Quarkus). Built reusable API-first platform services adopted by 8 product teams; championed inner-source practices. Reengineered release process from 2-week branches to trunk-based CI/CD with feature flags, cutting deployment lead time from 14 days to near real-time. Implemented Datadog observability (metrics, logs, traces) across Fargate services via sidecar agent and Java APM.
     
-    \item \textbf{E-commerce Tech Lead (2023–2024):} Led stabilization and modernization of a legacy B2B e-commerce platform across 6 markets, reducing over 600 security vulnerabilities to zero and improving operational reliability. Applied MACH architecture principles and IaC with Terraform. Initiated migration of containerized services from Azure to AWS to increase platform consistency and security.\\
-    Conducted technical interviews and contributed to hiring processes to strengthen the engineering team.
+    \item \textbf{E-commerce Tech Lead (2023–2024):} Led stabilization and modernization of a legacy B2B e-commerce platform across 6 markets, reducing over 600 security vulnerabilities to zero. Applied MACH architecture principles and IaC with Terraform. Initiated migration of containerized services from Azure to AWS for platform consistency and security. Contributed to engineering hiring.
 \end{itemize}
 }
 


### PR DESCRIPTION
## Summary
Updated CV to reflect current position as Tech Lead at Bose and refined professional summary, skills, and experience descriptions for clarity and accuracy.

## Key Changes

- **Professional Summary:** Updated to highlight current leadership role at Bose managing two B2B engineering teams, refined language for conciseness and impact
- **Skills Section:** 
  - Removed parenthetical clarification from Go (removed "serverless/Lambda")
  - Added new skills: Docker, Datadog, and a new "Data & Messaging" category (MongoDB, DynamoDB, DocumentDB, OpenSearch, Kafka)
  - Minor capitalization adjustments for consistency
- **Education:** Clarified postgraduate coursework description from generic "select MSc coursework" to specific "postgraduate coursework in Information Systems & Computer Engineering"
- **Experience - Bose:** Added team size context (~5 engineers each) for clarity on scope of leadership
- **Experience - Carlsberg:** 
  - Consolidated Platform Engineering Team (2022–2023) bullet point into a single paragraph for better readability
  - Condensed E-commerce Tech Lead (2023–2024) section, removing redundant details about technical interviews
  - Improved technical language precision (e.g., "fast cold-start, low overhead vs. Java/Quarkus")

## Notable Details
All changes maintain factual accuracy while improving CV presentation, readability, and relevance to current role and technical expertise.
